### PR TITLE
refactor: move config files to templates directory

### DIFF
--- a/src/strappa/main.py
+++ b/src/strappa/main.py
@@ -36,7 +36,7 @@ def run_in_venv(command: str, venv_path: Path = Path(".venv")) -> None:
         sys.exit(1)
 
 
-def copy_templates() -> None:
+def copy_config_files() -> None:
     create_files()
     print("Created requirements.txt and requirements-strappa.txt")
 
@@ -44,6 +44,7 @@ def setup_project() -> None:
     print("Setting up project in the current directory")
 
     create_virtual_environment()
+    copy_config_files()
 
     ensure_directory("src")
     ensure_directory("tests")

--- a/src/strappa/main.py
+++ b/src/strappa/main.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 import venv
 
-from strappa.utils import create_files, ensure_directory
+from strappa.utils import create_config_files, ensure_directory
 
 def create_virtual_environment(venv_path: Path = Path(".venv")) -> None:
     venv.create(venv_path, with_pip=True)
@@ -37,7 +37,7 @@ def run_in_venv(command: str, venv_path: Path = Path(".venv")) -> None:
 
 
 def copy_config_files() -> None:
-    create_files()
+    create_config_files()
     print("Created requirements.txt and requirements-strappa.txt")
 
 def setup_project() -> None:

--- a/src/strappa/main.py
+++ b/src/strappa/main.py
@@ -3,8 +3,7 @@ import sys
 from pathlib import Path
 import venv
 
-from strappa.utils import create_file, ensure_directory
-
+from strappa.utils import create_files, ensure_directory
 
 def create_virtual_environment(venv_path: Path = Path(".venv")) -> None:
     venv.create(venv_path, with_pip=True)
@@ -37,132 +36,14 @@ def run_in_venv(command: str, venv_path: Path = Path(".venv")) -> None:
         sys.exit(1)
 
 
-def create_pyproject_toml() -> None:
-    content = """
-[tool.pytest.ini_options]
-addopts = "-ra"
-testpaths = [
-    "tests",
-]
-pythonpath = ["src",]
-
-[tool.mypy]
-namespace_packages = true
-explicit_package_bases = true
-strict = true
-mypy_path = "src:."
-follow_imports = "silent"
-warn_redundant_casts = true
-warn_unused_ignores = true
-disallow_any_generics = true
-check_untyped_defs = true
-no_implicit_reexport = true
-exclude = ["tests/*"]
-
-[tool.pydantic-mypy]
-init_forbid_extra = true
-init_typed = true
-warn_required_dynamic_aliases = true
-
-[tool.ruff]
-line-length = 120
-indent-width = 4
-target-version = "py310"
-
-[tool.ruff.lint]
-select = ["E", "F", "I", "UP", "PTH", "G", "T10", "A", "PL", "RUF100", "PGH004", "N", "ANN", "EXE"]
-ignore = [
-"PLR0912", "PLR0915", "PLR2004", "PLR0913", "PLR1714", "PLR0911", # Over-opinionated
-"G004", # F-string in logging
-"UP028", # Use yield from
-"UP007", # "Use | instead for union
-"ANN002", "ANN003", "ANN101", "ANN102", "ANN201", "ANN202", "ANN204", "ANN401", # Type hints needed
-"I001", # No need as using formatter
-"PTH123", # Do not recommend using Path.open()
-]
-
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
-[tool.coverage.run]
-branch = true
-parallel = true
-omit = [
-    '__init__.py',
-    'tests/*',
-]
-
-[tool.coverage.report]
-skip_empty = true
-show_missing = true
-fail_under = 95
-exclude_lines = [
-    "pragma: no cover",
-    "case _:",
-    "raise NotImplementedError",
-]
-"""
-    create_file("pyproject.toml", content)
-    print("Created pyproject.toml")
-
-
-def create_makefile() -> None:
-    content = """
-[.PHONY: test
-test:
-    python3 -m pytest
-
-.PHONY: ruff
-ruff:
-    python3 -m ruff check --output-format=full
-
-.PHONY: ruff-fix
-ruff-fix:
-    python3 -m ruff check --fix
-
-.PHONY: mypy
-mypy:
-    python3 -m mypy ./src --check-untyped-defs
-
-.PHONY: format
-format:
-    python3 -m ruff format
-
-.PHONY: lint
-lint: ruff mypy
-
-.PHONY: coverage
-coverage:
-    python3 -m pytest --verbose --cov=.
-
-.PHONY: coverage-report
-coverage-report:
-    python3 -m pytest --verbose --cov=. --cov-report=html
-
-.PHONY: all_checks
-all_checks: format ruff-fix lint test ]
-"""
-    create_file("Makefile", content)
-    print("Created Makefile")
-
-
-def create_requirements_files() -> None:
-    strappa_requirements = """
-pytest
-ruff
-mypy
-pytest-cov
-"""
-    create_file("requirements.txt", strappa_requirements)
+def copy_templates() -> None:
+    create_files()
     print("Created requirements.txt and requirements-strappa.txt")
-
 
 def setup_project() -> None:
     print("Setting up project in the current directory")
 
     create_virtual_environment()
-    create_pyproject_toml()
-    create_makefile()
-    create_requirements_files()
 
     ensure_directory("src")
     ensure_directory("tests")

--- a/src/strappa/utils.py
+++ b/src/strappa/utils.py
@@ -1,10 +1,29 @@
 import subprocess
 from pathlib import Path
+from typing import Final
+
+TEMPLATES_DIR: Final = Path(__file__).parent.parent / "templates"
+
+def copy_template(template_name: str, dest_name: str) -> None:
+    """Copy a template file to the destination."""
+    template_path = TEMPLATES_DIR / template_name
+    dest_path = Path(dest_name)
+    
+    if not template_path.exists():
+        raise FileNotFoundError(f"Template {template_name} not found")
+        
+    dest_path.write_text(template_path.read_text())
+    print(f"Created {dest_name}")
+
+def create_config_files() -> None:
+    """Create all configuration files from templates."""
+    copy_template("pyproject.toml.template", "pyproject.toml")
+    copy_template("Makefile.template", "Makefile")
+    copy_template("requirements.txt.template", "requirements.txt")
 
 
-def create_file(filename: str, content: str) -> None:
-    with open(filename, "w") as f:
-        f.write(content.strip())
+def create_files() -> None:
+    create_config_files()
 
 
 def run_command(command: str) -> None:

--- a/src/strappa/utils.py
+++ b/src/strappa/utils.py
@@ -22,9 +22,6 @@ def create_config_files() -> None:
     copy_template("requirements.txt.template", "requirements.txt")
 
 
-def create_files() -> None:
-    create_config_files()
-
 
 def run_command(command: str) -> None:
     subprocess.run(command, shell=True, check=True)

--- a/src/templates/Makefile.template
+++ b/src/templates/Makefile.template
@@ -1,34 +1,33 @@
-[.PHONY: test
+.PHONY: test
 test:
-    python3 -m pytest
+	python3 -m pytest 
 
 .PHONY: ruff
 ruff:
-    python3 -m ruff check --output-format=full
+	python3 -m ruff check --output-format=full
 
 .PHONY: ruff-fix
 ruff-fix:
-    python3 -m ruff check --fix
+	python3 -m ruff check --fix
 
 .PHONY: mypy
 mypy:
-    python3 -m mypy ./src --check-untyped-defs
+	python3 -m mypy ./src --check-untyped-defs
 
 .PHONY: format
 format:
-    python3 -m ruff format
+	python3 -m ruff format
 
 .PHONY: lint
 lint: ruff mypy
 
 .PHONY: coverage
 coverage:
-    python3 -m pytest --verbose --cov=.
+	python3 -m pytest --verbose --cov=.
 
 .PHONY: coverage-report
 coverage-report:
-    python3 -m pytest --verbose --cov=. --cov-report=html
+	python3 -m pytest --verbose --cov=. --cov-report=html
 
 .PHONY: all_checks
-all_checks: format ruff-fix lint test ]
-
+all_checks: format ruff-fix lint test

--- a/src/templates/Makefile.template
+++ b/src/templates/Makefile.template
@@ -1,0 +1,34 @@
+[.PHONY: test
+test:
+    python3 -m pytest
+
+.PHONY: ruff
+ruff:
+    python3 -m ruff check --output-format=full
+
+.PHONY: ruff-fix
+ruff-fix:
+    python3 -m ruff check --fix
+
+.PHONY: mypy
+mypy:
+    python3 -m mypy ./src --check-untyped-defs
+
+.PHONY: format
+format:
+    python3 -m ruff format
+
+.PHONY: lint
+lint: ruff mypy
+
+.PHONY: coverage
+coverage:
+    python3 -m pytest --verbose --cov=.
+
+.PHONY: coverage-report
+coverage-report:
+    python3 -m pytest --verbose --cov=. --cov-report=html
+
+.PHONY: all_checks
+all_checks: format ruff-fix lint test ]
+

--- a/src/templates/pyproject.toml.template
+++ b/src/templates/pyproject.toml.template
@@ -1,0 +1,62 @@
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = [
+    "tests",
+]
+pythonpath = ["src",]
+
+[tool.mypy]
+namespace_packages = true
+explicit_package_bases = true
+strict = true
+mypy_path = "src:."
+follow_imports = "silent"
+warn_redundant_casts = true
+warn_unused_ignores = true
+disallow_any_generics = true
+check_untyped_defs = true
+no_implicit_reexport = true
+exclude = ["tests/*"]
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+
+[tool.ruff]
+line-length = 120
+indent-width = 4
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "PTH", "G", "T10", "A", "PL", "RUF100", "PGH004", "N", "ANN", "EXE"]
+ignore = [
+"PLR0912", "PLR0915", "PLR2004", "PLR0913", "PLR1714", "PLR0911", # Over-opinionated
+"G004", # F-string in logging
+"UP028", # Use yield from
+"UP007", # "Use | instead for union
+"ANN002", "ANN003", "ANN101", "ANN102", "ANN201", "ANN202", "ANN204", "ANN401", # Type hints needed
+"I001", # No need as using formatter
+"PTH123", # Do not recommend using Path.open()
+]
+
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.coverage.run]
+branch = true
+parallel = true
+omit = [
+    '__init__.py',
+    'tests/*',
+]
+
+[tool.coverage.report]
+skip_empty = true
+show_missing = true
+fail_under = 95
+exclude_lines = [
+    "pragma: no cover",
+    "case _:",
+    "raise NotImplementedError",
+]
+

--- a/src/templates/requirements.txt.template
+++ b/src/templates/requirements.txt.template
@@ -1,0 +1,5 @@
+pytest
+ruff
+mypy
+pytest-cov
+

--- a/tests/test_strappa.py
+++ b/tests/test_strappa.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from strappa.main import (
     get_activation_script,
     run_in_venv,
-    create_files
+    create_config_files
 )
 
 
@@ -43,7 +43,8 @@ def test_run_in_venv(mock_run: str):
 
 
 def test_create_files(temp_dir: temp_dir):
-    create_files()
+    create_config_files()
+
     assert (temp_dir / "pyproject.toml").exists()
     with open(temp_dir / "pyproject.toml") as f:  # no
         content = f.read()

--- a/tests/test_strappa.py
+++ b/tests/test_strappa.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 from typing import Any
 import pytest
+
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -10,8 +11,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from strappa.main import (
     get_activation_script,
     run_in_venv,
-    create_pyproject_toml,
-    create_makefile,
+    create_files
 )
 
 
@@ -42,17 +42,15 @@ def test_run_in_venv(mock_run: str):
     assert kwargs["check"] is True
 
 
-def test_create_pyproject_toml(temp_dir: temp_dir):
-    create_pyproject_toml()
+def test_create_files(temp_dir: temp_dir):
+    create_files()
     assert (temp_dir / "pyproject.toml").exists()
     with open(temp_dir / "pyproject.toml") as f:  # no
         content = f.read()
         assert "[tool.pytest.ini_options]" in content
 
-
-def test_create_makefile(temp_dir: temp_dir):
-    create_makefile()
     assert (temp_dir / "Makefile").exists()
+
     with open(temp_dir / "Makefile") as f:
         content = f.read()
         assert ".PHONY: test" in content


### PR DESCRIPTION

- Move configuration file contents to separate template files
- Add templates directory at project root
- Update config file creation to use templates
- Improve maintainability and ease of editing configs

Files affected:
- Added templates/pyproject.toml.template
- Added templates/Makefile.template
- Added templates/requirements.txt.template
- Modified src/strappa/config_files.py